### PR TITLE
jayeskay/AWS-16: Configure VS Code settings file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,3 @@
 {
-    "python-envs.pythonProjects": [
-        {
-            "path": "",
-            "envManager": "ms-python.python:pyenv",
-            "packageManager": "ms-python.python:pip"
-        }
-    ]
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }


### PR DESCRIPTION
Adds `settings.json` file for versioning/reference.

Original setting was auto-added to file for Python environment management, but this was stale. Checking with ChatGPT, only new rule suggested (for consistency/clarity) is configured in this change: `python.defaultInterpreterPath`.

Resolves #17 