### PR TITLE
jayeskay/AWS-27: Create profiles.yml for dbt project

### DIFF
--- a/src/app/transform/profiles.yml
+++ b/src/app/transform/profiles.yml
@@ -1,0 +1,25 @@
+postgres:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      user: "{{ env_var('DBT_POSTGRES_USER') }}"
+      password: "{{ env_var('DBT_POSTGRES_PASSWORD') }}"
+      port: 5432
+      dbname: dev
+      schema: dbt
+      threads: 1
+      connect_timeout: 10
+      retries: 1
+    prod:
+      type: postgres
+      host: localhost
+      user: "{{ env_var('DBT_POSTGRES_USER') }}"
+      password: "{{ env_var('DBT_POSTGRES_PASSWORD') }}"
+      port: 5432
+      dbname: prod
+      schema: dbt
+      threads: 1
+      connect_timeout: 10
+      retries: 1


### PR DESCRIPTION
Defines both "dev" and "prod" targets for Postgres instance running in Docker.

Username and password are stored as environment variables listed below:

- `DBT_POSTGRES_USER`
- `DBT_POSTGRES_PASSWORD`

These are resolved via `"{{ env_var('DBT_POSTGRES_[USER|PASSWORD]') }}"` Jinja reference in file.

Resolves #35 