### PR TITLE
jayeskay/AWS-36: Clean up .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,9 @@ cython_debug/
 # Marimo
 marimo/_static/
 marimo/_lsp/
+
+# dbt
+/src/app/transform/target/
+/src/app/transform/dbt_packages/
+/src/app/transform/logs/
+/src/app/transform/dbt_internal_packages/

--- a/src/app/transform/.gitignore
+++ b/src/app/transform/.gitignore
@@ -1,4 +1,0 @@
-
-target/
-dbt_packages/
-logs/


### PR DESCRIPTION
Consolidate dbt `.gitignore` into root `.gitignore` and add `dbt_internal_packages/`.

Resolves #50 