### PR TITLE
jayeskay/AWS-41: Add scope rule to commitlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,19 @@
           "revert",
           "test"
         ]
+      ],
+      "scope-empty": [1, "never"],
+      "scope-enum": [
+        2,
+        "always",
+        [
+          "extract",
+          "transform",
+          "load",
+          "data",
+          "schema",
+          "infra"
+        ]
       ]
     },
     "parserPreset": {


### PR DESCRIPTION
Add rules:

- `scope-empty`
- `scope-enum`

Note successful commit message (ignore that it's not true "infra" change):

```
[jayeskay/aws-41-addl-labels-unrecog-in-commit-messages 741d615] fix(infra): add scope rule to commitlint
```

Resolves #57 