### PR TITLE
jayeskay/test/AWS-30: Define accepted values for payment_type column for stg_nyc_tlc__green_taxi_trips

### DIFF
--- a/src/app/transform/models/staging/nyc_tlc/_nyc_tlc__models.yml
+++ b/src/app/transform/models/staging/nyc_tlc/_nyc_tlc__models.yml
@@ -62,6 +62,12 @@ models:
           - 4 = Dispute
           - 5 = Unknown
           - 6 = Voided trip
+        tests:
+          - accepted_values:
+              arguments:
+                values: [1, 2, 3, 4, 5, 6]
+                quote: false
+              severity: warn
       - name: trip_type
         description: |
           Code indicating whether the trip was a street-hail or a dispatch


### PR DESCRIPTION
# Problem

`payment_type` column for `stg_nyc_tlc__green_taxi_trips` table is defined, but it currently has no set accepted values for testing. This is needed for layer of data governance.

# Solution

## Summary

* Set accepted values in models YAML definition

Resolves jayeskay/aws-transit-data#43.